### PR TITLE
update `whatthapatch` to version `1.0.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,17 +10,18 @@ source:
   sha256: c540ea59173e0a291e19c742dd8b406c56e2be039a600edb7c6fc3ae4bbdfa9f
 
 build:
-  noarch: python
+  skip: True  # [py<37]
   script: {{ PYTHON }} -m pip install . -vv
   number: 0
 
 requirements:
   host:
-    - python >=3.7
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.7
-
+    - python
 test:
   imports:
     - whatthepatch


### PR DESCRIPTION
Update `whatthapatch` to version `1.0.2`. We need this package in order to build `python-lsp-server`

--


`whatthapatch` version `1.0.2`
1. - [x] Check the upstream
    https://github.com/cscorley/whatthepatch/tree/1.0.2
    
2. - [x] Check the pinnings

    `python 3.5`
    https://github.com/cscorley/whatthepatch/blob/1.0.2/setup.py#L35
    
    `setuptools`
    https://github.com/cscorley/whatthepatch/blob/1.0.2/setup.py#L4

3. - [x] Check the changelogs
    https://github.com/cscorley/whatthepatch/blob/1.0.2/HISTORY.md
    
4. - [x] Additional research

    The package is not available on `conda-forge`

5. - [x] Verify the `dev_url`
    https://github.com/cscorley/whatthepatch
    
6. - [x] Verify the `doc_url`
    https://github.com/cscorley/whatthepatch/blob/1.0.2/README.rst
    
7. - [x] License is `spdx` compliant
    MIT
    
8. - [x] License family is present
    MIT

9. - [x] Verify that the `build_number` is correct
10. - [x] Verify if the package needs `setuptools`
    
11. - [x] Verify if the package needs `wheel`
    
12. - [x] `pip` in the test section
    
13. - [x] Veriy the test section
14. - [x] Verify if the package is `architecture specific` or `Noarch`
15. - [x] Verify that private modules are not mentioned on the recipe For example: (_private_module)
 
Results:
- 
 
Based on the research findings and the results we can conclude
that it is safe to update `whatthapatch` to version `1.0.2`
